### PR TITLE
Preserve trailing slashes in Sitemap URLs

### DIFF
--- a/features/encoding.feature
+++ b/features/encoding.feature
@@ -9,3 +9,8 @@ Feature: Encode HTML entities
     Given a successfully built app at "subdirectories-app"
     When I cd to "build"
     Then the file "sitemap.xml" should contain "<loc>http://www.example.com/error-pages/404.html</loc>"
+
+  Scenario: Subdirectories
+    Given a successfully built app at "subdirectories-app"
+    When I cd to "build"
+    Then the file "sitemap.xml" should contain "<loc>http://www.example.com/error-pages/</loc>"

--- a/features/template.feature
+++ b/features/template.feature
@@ -3,7 +3,7 @@ Feature: Default template
   Scenario: Sitemap should have loc element
     Given a successfully built app at "template-app"
     When I cd to "build"
-    Then the file "sitemap.xml" should contain "<loc>http://www.example.com</loc>"
+    Then the file "sitemap.xml" should contain "<loc>http://www.example.com/</loc>"
 
   Scenario: Sitemap should not have lastmod element
     Given a successfully built app at "template-app"

--- a/lib/middleman-sitemap/extension.rb
+++ b/lib/middleman-sitemap/extension.rb
@@ -94,6 +94,7 @@ class Sitemap < ::Middleman::Extension
   # Returns a URL with proper HTML entities
   def encode(path)
     str = path.split("/").map { |f| h(f) }.join('/')
+    str += '/' if path.end_with?('/')
     return str
   end
 


### PR DESCRIPTION
If a page URL ends with a slash, the Sitemap should preserve it, in order to avoid 301 redirects and not confuse Google as to which is the canonical URL.

I am not entirely sure this is correct for the root URL, ie http://example.com/ vs http://example.com, but I suspect it might be okay.

This fixes https://github.com/statonjr/middleman-sitemap/issues/7